### PR TITLE
Run on Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -466,5 +466,5 @@ outputs:
   tools: # output will be available to future steps
     description: 'The number of tools installed'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
## Description

Transition from Node 16 to Node 20 to run the action.

## Motivation and context

Node.js 16 actions are deprecated.

## How has this been tested

Used the action in a workflow to verify it works with the updated Node.js version.
