### PR TITLE
Tidy up update-tools workflow

### DIFF
--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v7
       - name: Set Node.js 24.x
         uses: actions/setup-node@v6
         with:
@@ -25,11 +25,14 @@ jobs:
       - name: Install with npm
         run: |
           npm install
-      - uses: alexellis/setup-arkade@v3
+      - uses: alexellis/setup-arkade@v4
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: "1.26.x"
+          # The Go module lives in to-inputs/, not at the repo root,
+          # so the default build cache has nothing to key on.
+          cache: false
       - name: Regenerate changes
         run: |
           cd to-inputs


### PR DESCRIPTION
- Disable `setup-go`'s default build cache: the repo has no root `go.mod` (the only module is nested in `to-inputs/`), so every run warns "Restore cache failed". Go stays pinned at 1.26.x to match the fleet.
- Pin `actions/checkout` to v7 instead of the floating master ref.
- Move from `setup-arkade@v3` to the newly cut `v4`, which also fixes PATH resolution on minimal runner images.

Signed-off-by: Alex Ellis <alexellis2@gmail.com>